### PR TITLE
Fio plugin in spdk supports multi-stream

### DIFF
--- a/include/spdk/nvme.h
+++ b/include/spdk/nvme.h
@@ -499,6 +499,9 @@ struct spdk_nvme_transport_id {
 	 * information of this field can be found from the socket(7) man page.
 	 */
 	int priority;
+
+	/* for multistream */
+	uint16_t directive_id;
 };
 
 /**
@@ -3201,6 +3204,13 @@ int spdk_nvme_ns_cmd_writev_with_md(struct spdk_nvme_ns *ns, struct spdk_nvme_qp
 				    spdk_nvme_req_next_sge_cb next_sge_fn, void *metadata,
 				    uint16_t apptag_mask, uint16_t apptag);
 
+int spdk_nvme_ns_cmd_writev_with_md_with_directive(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
+				uint64_t lba, uint32_t lba_count,
+				spdk_nvme_cmd_cb cb_fn, void *cb_arg, uint32_t io_flags,
+				spdk_nvme_req_reset_sgl_cb reset_sgl_fn,
+				spdk_nvme_req_next_sge_cb next_sge_fn, void *metadata,
+				uint16_t apptag_mask, uint16_t apptag, uint16_t dspec); 
+
 /**
  * Submit a write I/O to the specified NVMe namespace.
  *
@@ -3265,6 +3275,12 @@ int spdk_nvme_ns_cmd_write_with_md(struct spdk_nvme_ns *ns, struct spdk_nvme_qpa
 				   uint64_t lba, uint32_t lba_count, spdk_nvme_cmd_cb cb_fn,
 				   void *cb_arg, uint32_t io_flags,
 				   uint16_t apptag_mask, uint16_t apptag);
+
+int spdk_nvme_ns_cmd_write_with_md_with_directive(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
+				   void *payload, void *metadata,
+				   uint64_t lba, uint32_t lba_count, spdk_nvme_cmd_cb cb_fn,
+				   void *cb_arg, uint32_t io_flags,
+				   uint16_t apptag_mask, uint16_t apptag, uint16_t directive);
 
 /**
  * Submit a write zeroes I/O to the specified NVMe namespace.

--- a/install_fio.sh
+++ b/install_fio.sh
@@ -1,0 +1,5 @@
+git clone https://github.com/axboe/fio
+cd fio
+make -j$(nproc)
+sudo make install
+

--- a/lib/nvme/nvme.c
+++ b/lib/nvme/nvme.c
@@ -1273,6 +1273,8 @@ spdk_nvme_transport_id_parse(struct spdk_nvme_transport_id *trid, const char *st
 			continue;
 		} else if (strcasecmp(key, "hostnqn") == 0) {
 			continue;
+		} else if (strcasecmp(key, "directive_id") == 0) {
+			trid->directive_id = spdk_strtol(val, 10);
 		} else if (strcasecmp(key, "ns") == 0) {
 			/*
 			 * Special case.  The namespace id parameter may

--- a/lib/nvme/nvme_ns_cmd.c
+++ b/lib/nvme/nvme_ns_cmd.c
@@ -986,6 +986,34 @@ spdk_nvme_ns_cmd_write_with_md(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *
 	}
 }
 
+int spdk_nvme_ns_cmd_write_with_md_with_directive(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
+			       void *buffer, void *metadata, uint64_t lba,
+			       uint32_t lba_count, spdk_nvme_cmd_cb cb_fn, void *cb_arg,
+			       uint32_t io_flags, uint16_t apptag_mask, uint16_t apptag, uint16_t directive)
+{
+	struct nvme_request *req;
+	struct nvme_payload payload;
+	int rc = 0;
+
+	if (!_is_io_flags_valid(io_flags)) {
+		return -EINVAL;
+	}
+
+	payload = NVME_PAYLOAD_CONTIG(buffer, metadata);
+
+	req = _nvme_ns_cmd_rw(ns, qpair, &payload, 0, 0, lba, lba_count, cb_fn, cb_arg, SPDK_NVME_OPC_WRITE,
+			      io_flags, apptag_mask, apptag, ((uint32_t)directive << 16), false, NULL, &rc);
+	if (req != NULL) {
+		return nvme_qpair_submit_request(qpair, req);
+	} else {
+		return nvme_ns_map_failure_rc(lba_count,
+					      ns->sectors_per_max_io,
+					      ns->sectors_per_stripe,
+					      qpair->ctrlr->opts.io_queue_requests,
+					      rc);
+	}
+}
+
 int
 spdk_nvme_ns_cmd_writev(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 			uint64_t lba, uint32_t lba_count,
@@ -1019,6 +1047,41 @@ spdk_nvme_ns_cmd_writev(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
 					      rc);
 	}
 }
+
+int
+spdk_nvme_ns_cmd_writev_with_md_with_directive(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,
+				uint64_t lba, uint32_t lba_count,
+				spdk_nvme_cmd_cb cb_fn, void *cb_arg, uint32_t io_flags,
+				spdk_nvme_req_reset_sgl_cb reset_sgl_fn,
+				spdk_nvme_req_next_sge_cb next_sge_fn, void *metadata,
+				uint16_t apptag_mask, uint16_t apptag, uint16_t directive) {
+	struct nvme_request *req;
+	struct nvme_payload payload;
+	int rc = 0;
+
+	if (!_is_io_flags_valid(io_flags)) {
+		return -EINVAL;
+	}
+
+	if (reset_sgl_fn == NULL || next_sge_fn == NULL) {
+		return -EINVAL;
+	}
+
+	payload = NVME_PAYLOAD_SGL(reset_sgl_fn, next_sge_fn, cb_arg, metadata);
+
+	req = _nvme_ns_cmd_rw(ns, qpair, &payload, 0, 0, lba, lba_count, cb_fn, cb_arg, SPDK_NVME_OPC_WRITE,
+			      io_flags, apptag_mask, apptag, ((uint32_t)directive << 16), true, NULL, &rc);
+	if (req != NULL) {
+		return nvme_qpair_submit_request(qpair, req);
+	} else {
+		return nvme_ns_map_failure_rc(lba_count,
+					      ns->sectors_per_max_io,
+					      ns->sectors_per_stripe,
+					      qpair->ctrlr->opts.io_queue_requests,
+					      rc);
+	}
+}
+
 
 int
 spdk_nvme_ns_cmd_writev_with_md(struct spdk_nvme_ns *ns, struct spdk_nvme_qpair *qpair,

--- a/lib/nvme/spdk_nvme.map
+++ b/lib/nvme/spdk_nvme.map
@@ -151,7 +151,9 @@
 	spdk_nvme_ns_cmd_write;
 	spdk_nvme_ns_cmd_writev;
 	spdk_nvme_ns_cmd_writev_with_md;
+	spdk_nvme_ns_cmd_writev_with_md_with_directive;
 	spdk_nvme_ns_cmd_write_with_md;
+	spdk_nvme_ns_cmd_write_with_md_with_directive;
 	spdk_nvme_ns_cmd_write_zeroes;
 	spdk_nvme_ns_cmd_write_uncorrectable;
 	spdk_nvme_ns_cmd_read;

--- a/multistream_fio.conf
+++ b/multistream_fio.conf
@@ -1,0 +1,23 @@
+# spdk_fio_nvme_example.fio
+[global]
+ioengine=build/fio/spdk_nvme
+thread=1
+group_reporting=1
+direct=1
+verify=0
+
+[job0]
+rw=randwrite
+bs=4k
+numjobs=4
+time_based=1
+runtime=60
+filename=trtype=PCIe traddr=0001\:10\:00.0 directive_id=1 ns=1
+
+[job1]
+rw=randwrite
+bs=4k
+numjobs=4
+time_based=1
+runtime=60
+filename=trtype=PCIe traddr=0001\:10\:00.0 directive_id=2 ns=1

--- a/setup_spdk.sh
+++ b/setup_spdk.sh
@@ -1,0 +1,8 @@
+pagesize_kb=$(grep Hugepagesize /proc/meminfo | awk '{print $2}')
+required_kb=$((2 * 1024 * 1024))
+pages=$((required_kb / pagesize_kb))
+echo "Required pages: $pages"
+
+sudo sysctl -w vm.nr_hugepages=$pages
+sudo ./scripts/setup.sh
+sudo HUGEMEM=2048 DRIVER_OVERRIDE=uio_pci_generic ./scripts/setup.sh


### PR DESCRIPTION
- add directive option to filename when using nvme fio plugin in spdk
- add example files for fio configuration
- add scripts for installing fio and setup spdk

Test
- fio multistream_fio.conf